### PR TITLE
commands (jsreport-studio-build, jsreport-studio-start) not working on OSX

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 var webpack = require('webpack')
 
 var exposedLibraries = ['react', 'react-dom', 'superagent', 'react-list', 'bluebird', 'socket.io-client', 'filesaver.js-npm']

--- a/bin/start.js
+++ b/bin/start.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 var fs = require('fs')
 var path = require('path')
 var execSync = require('child_process').execSync
@@ -53,4 +53,3 @@ var jsreport = require(path.join(process.cwd(), 'node_modules', 'jsreport'))
 jsreport().init().catch(function (e) {
   console.error(e)
 })
-


### PR DESCRIPTION
issue encountered while trying to publish `jsreport-jade`

![command-bug](https://cloud.githubusercontent.com/assets/4262050/16367523/fe7adeae-3be9-11e6-9ce4-e66578b6b23c.gif)

seems like a problem with the space in the hashbang, with this change i have been able to build normally
